### PR TITLE
Remove dependency on he.js and do our own escaping

### DIFF
--- a/country-currency-map.js
+++ b/country-currency-map.js
@@ -1,7 +1,13 @@
 import countryMap from './country-map';
 import currencyMap from './currency-map';
 import _ from 'lodash';
-import he from 'he';
+
+// mapping of escaped currency symbol (eg '&euro;') to actual currency character
+const currencySymbolMap = {
+    'pound': '\xA3',
+    'euro': '\u20AC',
+    'yen': '\xA5'
+};
 
 function getCountry(countryName) {
     return countryMap[countryName];
@@ -22,7 +28,9 @@ function getCurrencyAbbreviation(countryName) {
 function formatCurrency(value, currencyAbbr) {
     let currency = getCurrency(currencyAbbr);
     if(currency) {
-        return he.decode(currency.symbolFormat).replace('{#}', value);
+        return currency.symbolFormat
+            .replace(/&(\w+);/, (match, p1) => currencySymbolMap[p1] || p1)
+            .replace('{#}', value);
     }
     return `${value} ${currencyAbbr}`;
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "webpack": "^2.3.2"
   },
   "dependencies": {
-    "he": "^1.1.1",
     "lodash": "^4.17.4"
   }
 }

--- a/test.js
+++ b/test.js
@@ -44,9 +44,19 @@ describe('country-currency-map', () => {
         chai.expect(result).to.equal('100,000 NONE');
     });
 
-    it('formatCurrency decodes', () => {
+    it('formatCurrency returns expected value for EUR', () => {
         let result = formatCurrency('100,000', 'EUR');
         chai.expect(result).to.equal('€100,000');
+    });
+
+    it('formatCurrency returns expected value for JPY', () => {
+        let result = formatCurrency('100,000', 'JPY');
+        chai.expect(result).to.equal('¥100,000');
+    });
+
+    it('formatCurrency returns expected value for GBP', () => {
+        let result = formatCurrency('100,000', 'GBP');
+        chai.expect(result).to.equal('£100,000');
     });
 
     it('getCountryByAbbreviation returns expected value', () => {


### PR DESCRIPTION
He.js is very heavy-weight for what we're doing with it -- largely turning certain escaped characters into the character literals (and only 3 unique characters).

Use our own lookup table/map to do the replacement rather than rely on an external library