### PR TITLE
Fix SEK should have kr after amount

### DIFF
--- a/currency-map.js
+++ b/currency-map.js
@@ -549,7 +549,7 @@ module.exports = {
     },
     'SEK': {
         'name': 'Swedish Krona (SEK)',
-        'symbolFormat': 'kr {#}'
+        'symbolFormat': '{#} kr'
     },
     'CHF': {
         'name': 'Swiss Franc (CHF)',


### PR DESCRIPTION
When writing SEK the kr should come after the amount, eg. `100 kr`