### PR TITLE
Adding window check for navigator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "country-currency-map",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Mapping of countries and their primary currency.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/formatCurrency.js
+++ b/src/formatCurrency.js
@@ -82,7 +82,7 @@ export const formatLocaleCurrency = (value, currency, options = {}) => {
   }
 
   if (!locale) {
-    locale = navigator && navigator.language ? navigator.language : 'en-US';
+    locale = typeof window !== 'undefined' && window !== null && window.navigator && window.navigator.language ? window.navigator.language : 'en-US';
   }
 
   if (abbrResult) {


### PR DESCRIPTION
RCW was getting errors that navigator was not defined. Navigator lives in the window object which is native to browsers, but is not available server side, so adding a window check should solve the undefined issue.